### PR TITLE
Fix deprecated notations of Ansible

### DIFF
--- a/playbooks/enter_hdfs_safemode.yml
+++ b/playbooks/enter_hdfs_safemode.yml
@@ -1,8 +1,8 @@
 ## 前提1: HDFSへのアクセス(読み書き)が行われていないこと
 
 - hosts: hadoop_namenode
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   tasks:
     - name: HDFS_enter_safemode
       shell: hdfs dfsadmin -safemode enter

--- a/playbooks/get_swimlane_analyze.yml
+++ b/playbooks/get_swimlane_analyze.yml
@@ -1,11 +1,11 @@
 - hosts: hadoop_swimlane
   tasks:
     - name: start_httpd
-      sudo: yes
+      become: yes
       service: name=httpd state=started
 
     - name: delete_swimlane_old_output
-      sudo: yes
+      become: yes
       file: path={{ item }}/{{ yarn_application_id }}.svg state=absent
       with_items:
       - "{{ swimlane_httpd_path}}/{{ swimlane_httpd_prefix }}"
@@ -17,9 +17,9 @@
         chdir: "{{ swimlane_install_path }}/apache-tez-{{ swimlane_tez_version }}-src/tez-tools/swimlanes/"
   
     - name: move_to_httpd_path
-      sudo: yes
+      become: yes
       shell: mv {{ swimlane_install_path }}/apache-tez-{{ swimlane_tez_version }}-src/tez-tools/swimlanes/{{ yarn_application_id }}.svg {{ swimlane_httpd_path }}/{{ swimlane_httpd_prefix }}
     
     - name: show_http_url
-      sudo: yes
+      become: yes
       debug: msg=http://{{ inventory_hostname }}/{{ swimlane_httpd_prefix }}/{{ yarn_application_id }}.svg

--- a/playbooks/install-base.yml
+++ b/playbooks/install-base.yml
@@ -1,5 +1,5 @@
 - hosts: hadoop_all
-  sudo: yes
+  become: yes
   roles:
   - os
   - cgroups

--- a/playbooks/roles/base/tasks/conf.yml
+++ b/playbooks/roles/base/tasks/conf.yml
@@ -1,9 +1,9 @@
 - name: create_hadoop_conf_dir
-  sudo: yes
+  become: yes
   file: path={{ hadoop_conf_dir }} state=directory owner=root group=root mode=755
 
 - name: copy_conf_files
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/hadoop/conf/{{ item }}
   with_items:
   - core-site.xml
@@ -21,7 +21,7 @@
   - hosts.list
   
 - name: copy_secure_conf_files
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/hadoop/conf/{{ item }}
   with_items:
   - ssl-server.xml

--- a/playbooks/roles/base/tasks/main.yml
+++ b/playbooks/roles/base/tasks/main.yml
@@ -1,7 +1,6 @@
-- include: repo.yml tags=repo,base
-#- include: install.yml tags=install,cdh5_base
-- include: conf.yml tags=conf,base
+- include: repo.yml
+- include: conf.yml
 
-- include: kerberos.yml tags=conf,base
+- include: kerberos.yml
   become: yes
   when: kerberos_realm is defined

--- a/playbooks/roles/base/tasks/repo.yml
+++ b/playbooks/roles/base/tasks/repo.yml
@@ -1,3 +1,3 @@
 - name: install_hdp_repo
-  sudo: yes
+  become: yes
   template: src=hdp.repo.j2 dest=/etc/yum.repos.d/hdp.repo

--- a/playbooks/roles/cgroups/tasks/conf.yml
+++ b/playbooks/roles/cgroups/tasks/conf.yml
@@ -1,19 +1,19 @@
 - name: create_direcoty_cgroups_scripts
-  sudo: yes
+  become: yes
   file: path={{ cgroups_scripts_dir }} state=directory owner=root group=root mode=755
 
 - name: copy_cgroups_scripts
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest={{ cgroups_scripts_dir }}/{{ item }} owner=root group=root mode=755
   with_items:
     - cgroups.sh
 
 - name: copy_cgconfig.conf
-  sudo: yes
+  become: yes
   template: src=cgconfig.conf.j2 dest=/etc/cgconfig.conf owner=root group=root mode=644
 
 - name: check_chkconfig_cgconfig
-  sudo: yes
+  become: yes
   shell: chkconfig --list | grep cgconfig | grep on
   ignore_errors: true
   register: check_chkconfig_cgconfig
@@ -21,16 +21,16 @@
   always_run: true
   
 - name: set_on_to_cgconfig_of_chkconfig
-  sudo: yes
+  become: yes
   shell: chkconfig cgconfig on
   when: check_chkconfig_cgconfig.rc != 0
   
 - name: started_cgconfig
-  sudo: yes
+  become: yes
   service: name=cgconfig state=started
 
 - name: reboot
-  sudo: yes
+  become: yes
   command: shutdown -r now
   when: result_install_cgroups.changed
 
@@ -44,5 +44,5 @@
   when: result_install_cgroups.changed
   
 - name: started_cgconfig
-  sudo: yes
+  become: yes
   service: name=cgconfig state=started

--- a/playbooks/roles/cgroups/tasks/install.yml
+++ b/playbooks/roles/cgroups/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_cgroups
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   register: result_install_cgroups
   with_items:

--- a/playbooks/roles/cgroups/tasks/main.yml
+++ b/playbooks/roles/cgroups/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,cgroups
-- include: conf.yml tags=conf,cgroups
+- include: install.yml
+- include: conf.yml

--- a/playbooks/roles/cgroups/tasks/resource.yml
+++ b/playbooks/roles/cgroups/tasks/resource.yml
@@ -1,10 +1,10 @@
 - name: create_settings_cgroups_group_settings
-  sudo: yes
+  become: yes
   template: src=settings.sh.j2 dest={{ cgroups_scripts_dir }}/settings/group/{{ item.group }} owner=root group=root mode=755
   with_items: cgroups_group_settings
 
 - name: create_settings_cgroups_process_settings
-  sudo: yes
+  become: yes
   template: src=settings.sh.j2 dest={{ cgroups_scripts_dir }}/settings/process/{{ item.process }} owner=root group=root mode=755
   with_items: cgroups_process_settings
 

--- a/playbooks/roles/client/tasks/install.yml
+++ b/playbooks/roles/client/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_hadoop-client_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hadoop-client

--- a/playbooks/roles/client/tasks/main.yml
+++ b/playbooks/roles/client/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: install.yml tags=install,client
+- include: install.yml

--- a/playbooks/roles/datanode_server_deletedata/tasks/delete.yml
+++ b/playbooks/roles/datanode_server_deletedata/tasks/delete.yml
@@ -1,5 +1,5 @@
 - name: check_datanode_data_dirs
-  sudo: yes
+  become: yes
   shell: ls {{ item }}/*
   with_items: dfs_datanode_data_dirs
   register: check_datanode_data_dirs
@@ -8,13 +8,13 @@
   always_run: true
 
 - name: delete_datanode_data_dirs
-  sudo: yes
+  become: yes
   file: path={{ item.item }} state=absent
   with_items: check_datanode_data_dirs.results
   when: item.rc == 0
   
 - name: recreate_datanode_data_dirs
-  sudo: yes
+  become: yes
   file: path={{ item.item }} state=directory mode=755 owner=hdfs group=hadoop
   with_items: check_datanode_data_dirs.results
   when: item.rc == 0

--- a/playbooks/roles/datanode_server_deletedata/tasks/main.yml
+++ b/playbooks/roles/datanode_server_deletedata/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: delete.yml tags=delete,datanode
+- include: delete.yml
 

--- a/playbooks/roles/hbase_master/tasks/config.yml
+++ b/playbooks/roles/hbase_master/tasks/config.yml
@@ -1,19 +1,19 @@
 - name: create_hbase_conf_dir
-  sudo: yes
+  become: yes
   file: path=/etc/hbase/conf state=directory owner=root group=root mode=755
 
 - include: principal.yml
-  sudo: yes
+  become: yes
   vars: { kerberos_princ_username: hbase, kerberos_princ_keytab_path: /etc/hbase/conf/hbase.keytab, kerberos_princ_keytab_owner: hbase }
   when: kerberos_realm is defined
 
 - name: copy_jaas_conf
-  sudo: yes
+  become: yes
   template: src=zk-jaas.conf.j2 dest=/etc/hbase/conf/zk-jaas.conf
   when: kerberos_realm is defined
 
 - name: copy_hbase_conf_files
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/hbase/conf/{{ item }} owner=hbase group=hadoop mode=755
   with_items:
   - hbase-site.xml
@@ -24,7 +24,7 @@
   - hadoop-metrics2-hbase.properties
   
 - name: copy_hbase_default_file
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/default/{{ item }} owner=hbase group=hadoop mode=755
   with_items:
   - hbase-master
@@ -40,17 +40,17 @@
   lineinfile: dest=/usr/hdp/{{ hdp_version }}/hbase/etc/rc.d/init.d/hbase-master regexp='^export\s+HBASE_HOME=' state=absent
 
 - name: create_symbolic_link_to/etc/init.d
-  sudo: yes
+  become: yes
   file: path=/etc/init.d/{{ item }} state=link src=/usr/hdp/{{ hdp_version }}/hbase/etc/rc.d/init.d/{{ item }}
   with_items:
   - hbase-master
   
 - name: create_hbase_log_dir
-  sudo: yes
+  become: yes
   file: path={{ hbase_log_dir }} state=directory mode=755 owner=hbase group=hadoop 
 
 - name: deploy_service_test_script
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/usr/local/bin/{{ item }} owner=hbase group=hadoop mode=644
   with_items:
     - hbase-service-test.rb

--- a/playbooks/roles/hbase_master/tasks/install.yml
+++ b/playbooks/roles/hbase_master/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_hbase-master_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hbase-master

--- a/playbooks/roles/hbase_master/tasks/main.yml
+++ b/playbooks/roles/hbase_master/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,hbase_master
-- include: config.yml tags=config,hbase_master
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/hbase_regionserver/tasks/config.yml
+++ b/playbooks/roles/hbase_regionserver/tasks/config.yml
@@ -1,19 +1,19 @@
 - name: create_hbase_conf_dir
-  sudo: yes
+  become: yes
   file: path=/etc/hbase/conf state=directory owner=root group=root mode=755  
 
 - include: principal.yml
-  sudo: yes
+  become: yes
   vars: { kerberos_princ_username: hbase, kerberos_princ_keytab_path: /etc/hbase/conf/hbase.keytab, kerberos_princ_keytab_owner: hbase }
   when: kerberos_realm is defined
 
 - name: copy_jaas_conf
-  sudo: yes
+  become: yes
   template: src=zk-jaas.conf.j2 dest=/etc/hbase/conf/zk-jaas.conf
   when: kerberos_realm is defined
 
 - name: copy_hbase_conf_files
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/hbase/conf/{{ item }} owner=hbase group=hadoop mode=755
   with_items:
   - hbase-site.xml
@@ -24,7 +24,7 @@
   - hadoop-metrics2-hbase.properties
   
 - name: copy_hbase_default_file
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/default/{{ item }} owner=hbase group=hadoop mode=755
   with_items:
   - hbase-regionserver
@@ -40,23 +40,23 @@
   lineinfile: dest=/usr/hdp/{{ hdp_version }}/hbase/etc/rc.d/init.d/hbase-regionserver regexp='^export\s+HBASE_HOME=' state=absent
   
 - name: create_symbolic_link_to/etc/init.d
-  sudo: yes
+  become: yes
   file: path=/etc/init.d/{{ item }} state=link src=/usr/hdp/{{ hdp_version }}/hbase/etc/rc.d/init.d/{{ item }}
   with_items:
   - hbase-regionserver
   
 - name: create_hbase_log_dir
-  sudo: yes
+  become: yes
   file: path={{ hbase_log_dir }} state=directory mode=755 owner=hbase group=hadoop 
 
 - name: deploy_graceful_stop_script_from_upstream
-  sudo: yes
+  become: yes
   copy: src={{ item }} dest=/usr/local/bin/hbase-{{ item }} owner=hbase group=hadoop mode=755
   with_items:
   - graceful_stop.sh
 
 - name: create_symbolic_link_for_graceful_stop_script
-  sudo: yes
+  become: yes
   file: path=/usr/hdp/current/hbase-client/bin/{{ item }} state=link src=/usr/local/bin/hbase-{{ item }}
   with_items:
   - graceful_stop.sh

--- a/playbooks/roles/hbase_regionserver/tasks/install.yml
+++ b/playbooks/roles/hbase_regionserver/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_hbase-regionserver_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hbase-regionserver

--- a/playbooks/roles/hbase_regionserver/tasks/main.yml
+++ b/playbooks/roles/hbase_regionserver/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,hbase_master
-- include: config.yml tags=config,hbase_master
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/hcatalog/tasks/config.yml
+++ b/playbooks/roles/hcatalog/tasks/config.yml
@@ -1,21 +1,21 @@
 - name: create_hcatalog_conf_dir
-  sudo: yes
+  become: yes
   file: path=/etc/hive-hcatalog/conf state=directory owner=root group=root mode=755
   
 - name: copy_conf_files
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/hive-hcatalog/conf/{{ item }} owner=hive group=hadoop mode=755
   with_items:
   - hcat-env.sh
 
 - name: create_hcatalog_log_dir
-  sudo: yes
+  become: yes
   file: path={{ hcatalog_log_dir }} state=directory owner=hive group=hadoop mode=755
 
 - name: create_hcatalog_var_dir
-  sudo: yes
+  become: yes
   file: path=/usr/hdp/current/hive-webhcat/var state=directory owner=hive group=hive mode=775
   
 - name: create_symbolic_link_to_log_dir
-  sudo: yes
+  become: yes
   file: path=/usr/hdp/current/hive-webhcat/var/log state=link src={{ hcatalog_log_dir }}

--- a/playbooks/roles/hcatalog/tasks/install.yml
+++ b/playbooks/roles/hcatalog/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_hcatalog_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hive-hcatalog

--- a/playbooks/roles/hcatalog/tasks/main.yml
+++ b/playbooks/roles/hcatalog/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,hcatalog
-- include: config.yml tags=config,hcatalog
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/hdfs_base/tasks/config.yml
+++ b/playbooks/roles/hdfs_base/tasks/config.yml
@@ -1,6 +1,6 @@
 - name: check_hdfs_root_permission
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: echo "$(hdfs dfs -ls -d /)" | grep "drwxrwxrwx"
   register: check_hdfs_root_permission
   changed_when: false
@@ -8,14 +8,14 @@
   always_run: yes
 
 - name: chmod_hdfs_root
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -chmod 777 /
   when: check_hdfs_root_permission.rc != 0
 
 - name: check_exists_hfds_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -ls {{ item.path }}
   register: check_exists_hdfs_dir
   changed_when: false
@@ -26,22 +26,22 @@
     - {path: '/user', mode: '1777', owner: 'hdfs', group: 'hadoop'}
     
 - name: create_hdfs_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -mkdir -p {{ item.item.path }}
   when: item.rc != 0
   with_items: check_exists_hdfs_dir.results
   
 - name: change_owner_and_group_of_hdfs_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -chown -R {{ item.item.owner }}:{{ item.item.group }} {{ item.item.path }}
   when: item.rc != 0
   with_items: check_exists_hdfs_dir.results
 
 - name: change_mode_of_hdfs_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -chmod -R {{ item.item.mode }} {{ item.item.path }}
   when: item.rc != 0
   with_items: check_exists_hdfs_dir.results

--- a/playbooks/roles/hdfs_base/tasks/main.yml
+++ b/playbooks/roles/hdfs_base/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: config.yml tags=config,hdfs_base
+- include: config.yml

--- a/playbooks/roles/hdfs_spark/tasks/config.yml
+++ b/playbooks/roles/hdfs_spark/tasks/config.yml
@@ -1,6 +1,6 @@
 - name: check_exists_hfds_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -ls {{ spark_event_log_dir }}
   register: check_exists_hdfs_dir
   changed_when: false
@@ -8,19 +8,19 @@
   always_run: true
     
 - name: create_hdfs_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -mkdir -p {{ spark_event_log_dir }}
   when: check_exists_hdfs_dir.rc != 0
   
 - name: change_owner_and_group_of_hdfs_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -chown -R spark:spark {{ spark_event_log_dir }}
   when: check_exists_hdfs_dir.rc != 0
 
 - name: change_mode_of_hdfs_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -chmod -R 1777 {{ spark_event_log_dir }}
   when: check_exists_hdfs_dir.rc != 0

--- a/playbooks/roles/hdfs_spark/tasks/main.yml
+++ b/playbooks/roles/hdfs_spark/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: config.yml tags=config,hdfs_spark
+- include: config.yml

--- a/playbooks/roles/hdfs_tez/tasks/config.yml
+++ b/playbooks/roles/hdfs_tez/tasks/config.yml
@@ -1,6 +1,6 @@
 - name: check_exists_hfds_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -ls {{ tez_hdfs_dir }}
   register: check_exists_hdfs_dir
   changed_when: false
@@ -8,19 +8,19 @@
   always_run: true
     
 - name: create_hdfs_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -mkdir -p {{ tez_hdfs_dir }}
   when: check_exists_hdfs_dir.rc != 0
   
 - name: change_owner_and_group_of_hdfs_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -chown -R hdfs:hadoop {{ tez_hdfs_dir }}
   when: check_exists_hdfs_dir.rc != 0
 
 - name: change_mode_of_hdfs_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -chmod -R 555 {{ tez_hdfs_dir }}
   when: check_exists_hdfs_dir.rc != 0

--- a/playbooks/roles/hdfs_tez/tasks/main.yml
+++ b/playbooks/roles/hdfs_tez/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: config.yml tags=config,hdfs_tez
+- include: config.yml

--- a/playbooks/roles/hdfs_yarn/tasks/config.yml
+++ b/playbooks/roles/hdfs_yarn/tasks/config.yml
@@ -1,6 +1,6 @@
 - name: check_exists_hfds_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -ls {{ item.path }}
   register: check_exists_hdfs_dir
   changed_when: false
@@ -16,22 +16,22 @@
     - {path: '/tmp/hadoop-yarn/staging', mode: '1777', owner: 'mapred', group: 'hadoop'}
     
 - name: create_hdfs_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -mkdir -p {{ item.item.path }}
   when: item.rc != 0
   with_items: check_exists_hdfs_dir.results
   
 - name: change_owner_and_group_of_hdfs_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -chown -R {{ item.item.owner }}:{{ item.item.group }} {{ item.item.path }}
   when: item.rc != 0
   with_items: check_exists_hdfs_dir.results
 
 - name: change_mode_of_hdfs_dir
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -chmod -R {{ item.item.mode }} {{ item.item.path }}
   when: item.rc != 0
   with_items: check_exists_hdfs_dir.results

--- a/playbooks/roles/hdfs_yarn/tasks/main.yml
+++ b/playbooks/roles/hdfs_yarn/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: config.yml tags=config,hdfs_yarn
+- include: config.yml

--- a/playbooks/roles/hive/tasks/config.yml
+++ b/playbooks/roles/hive/tasks/config.yml
@@ -1,18 +1,18 @@
 - name: create_hive_metastore_dir
-  sudo: yes
+  become: yes
   file: path={{ hive_metastore_dir }} state=directory owner=hive group=hadoop mode=777
 
 - name: create_hive_conf_dir
-  sudo: yes
+  become: yes
   file: path=/etc/hive/conf state=directory owner=root group=root mode=755
 
 - include: principal.yml
-  sudo: yes
+  become: yes
   vars: { kerberos_princ_username: hive, kerberos_princ_keytab_path: /etc/hive/conf/hive.keytab, kerberos_princ_keytab_owner: hive }
   when: kerberos_realm is defined
 
 - name: copy_hive_conf
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/hive/conf/{{ item }} owner=root group=root mode=755
   with_items:
   - hive-site.xml

--- a/playbooks/roles/hive/tasks/install.yml
+++ b/playbooks/roles/hive/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_hive_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hive

--- a/playbooks/roles/hive/tasks/main.yml
+++ b/playbooks/roles/hive/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,hive
-- include: config.yml tags=config,hive
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/httpfs/tasks/config.yml
+++ b/playbooks/roles/httpfs/tasks/config.yml
@@ -1,29 +1,29 @@
 - name: create_httpfs_temp_dir
-  sudo: yes
+  become: yes
   file: path={{ httpfs_temp_dir }} state=directory owner=httpfs group=hadoop mode=775
 
 - name: create_symbolic_link_to_libexec
-  sudo: yes
+  become: yes
   file: path=/usr/hdp/{{ hdp_version }}/hadoop-httpfs/libexec state=link src=/usr/hdp/{{ hdp_version }}/hadoop/libexec 
 
 - name: fix_launcher_script
-  sudo: yes
+  become: yes
   template: src=httpfs.sh.j2 dest=/usr/hdp/{{ hdp_version }}/hadoop-httpfs/sbin/httpfs.sh owner=root group=root mode=755
 
 - name: fix_etc_default
-  sudo: yes
+  become: yes
   template: src=hadoop-httpfs-default.j2 dest=/usr/hdp/{{ hdp_version }}/etc/default/hadoop-httpfs
 
 - name: create_symbolic_link_to_/etc/default
-  sudo: yes
+  become: yes
   file: path=/etc/default/hadoop-httpfs state=link src=/usr/hdp/{{ hdp_version }}/etc/default/hadoop-httpfs
 
 - name: create_httpfs_conf_dir
-  sudo: yes
+  become: yes
   file: path=/etc/hadoop-httpfs/conf state=directory owner=root group=root mode=755
   
 - name: copy_httpfs_conf_file
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/hadoop-httpfs/conf/{{ item }} owner=root group=root mode=755
   with_items:
   - httpfs-site.xml
@@ -32,13 +32,13 @@
   - httpfs-signature.secret
 
 - name: fix_init_scripts
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/usr/hdp/{{ hdp_version }}/etc/rc.d/init.d/{{ item }} mode=755
   with_items:
   - hadoop-httpfs
   
 - name: create_symbolic_link_to/etc/init.d
-  sudo: yes
+  become: yes
   file: path=/etc/init.d/{{ item }} state=link src=/usr/hdp/{{ hdp_version }}/etc/rc.d/init.d/{{ item }}
   with_items:
   - hadoop-httpfs

--- a/playbooks/roles/httpfs/tasks/install.yml
+++ b/playbooks/roles/httpfs/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_httpfs_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hadoop-httpfs

--- a/playbooks/roles/httpfs/tasks/main.yml
+++ b/playbooks/roles/httpfs/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,httpfs
-- include: config.yml tags=config,httpfs
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/hue/tasks/config.yml
+++ b/playbooks/roles/hue/tasks/config.yml
@@ -1,9 +1,9 @@
 - name: create_hue_data_dir
-  sudo: yes
+  become: yes
   file: path={{ hue_data_dir }} state=directory owner=hue group=hadoop mode=755
 
 - name: copy_hue_conf
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/hue/conf/{{ item }} owner=root group=root mode=755
   with_items:
   - hue.ini
@@ -15,8 +15,8 @@
   register: check_hue_db_stat
 
 - name: sync_db_for_hue
-  sudo: yes
-  sudo_user: hue
+  become: yes
+  become_user: hue
   shell: /usr/lib/hue/build/env/bin/hue syncdb --noinput
   when: not check_hue_db_stat.stat.exists
 

--- a/playbooks/roles/hue/tasks/install.yml
+++ b/playbooks/roles/hue/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_hue_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hue

--- a/playbooks/roles/hue/tasks/main.yml
+++ b/playbooks/roles/hue/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,hue
-- include: config.yml tags=config,hue
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/java7/tasks/config.yml
+++ b/playbooks/roles/java7/tasks/config.yml
@@ -1,7 +1,7 @@
 - name: copy_bash_profile
-  sudo: yes
+  become: yes
   copy: src=java.sh dest=/etc/profile.d/
 
 - name: copy_sudoers_conf_of_JAVA_HOME
-  sudo: yes
+  become: yes
   copy: src=env_keep_javahome dest=/etc/sudoers.d mode=440 owner=root

--- a/playbooks/roles/java7/tasks/install.yml
+++ b/playbooks/roles/java7/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: check_jdk7_installed
-  sudo: yes
+  become: yes
   shell: rpm -qa|grep jdk-1.7.0_{{ jdk7_version }}-fcs.x86_64
   ignore_errors: yes
   changed_when: false
@@ -26,6 +26,6 @@
   when: check_jdk7_installed.rc != 0 and md5sum_of_jdk.stdout.find('{{ jdk7_md5sum }}')
 
 - name: install_oraclejdk
-  sudo: yes
+  become: yes
   yum: name={{ jdk7_tmppath }}/jdk-7u{{ jdk7_version }}-linux-x64.rpm state=installed
   when: check_jdk7_installed.rc != 0

--- a/playbooks/roles/java7/tasks/main.yml
+++ b/playbooks/roles/java7/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,jdk
-- include: config.yml tags=config,jdk
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/java8/tasks/install.yml
+++ b/playbooks/roles/java8/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: check_jdk8_installed
-  sudo: yes
+  become: yes
   shell: rpm -qa | grep -e "jdk.*-1.8.0_{{ jdk8_version }}-fcs.x86_64"
   ignore_errors: yes
   changed_when: false
@@ -26,6 +26,6 @@
   when: check_jdk8_installed.rc != 0 and md5sum_of_jdk.stdout.find('{{ jdk8_md5sum }}')
 
 - name: install_oraclejdk
-  sudo: yes
+  become: yes
   yum: name={{ jdk8_tmppath }}/jdk-8u{{ jdk8_version }}-linux-x64.rpm state=installed
   when: check_jdk8_installed.rc != 0

--- a/playbooks/roles/java8/tasks/main.yml
+++ b/playbooks/roles/java8/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: install.yml tags=install,jdk
+- include: install.yml

--- a/playbooks/roles/journalnode/tasks/config.yml
+++ b/playbooks/roles/journalnode/tasks/config.yml
@@ -1,5 +1,5 @@
 - name: create_journalnode_data_dir
-  sudo: yes
+  become: yes
   file: path={{ dfs_journalnode_edits_dir }} state=directory owner=hdfs group=hadoop mode=700
 
 - name: fix_init_scripts
@@ -9,17 +9,17 @@
   - hadoop-hdfs-journalnode
   
 - name: create_symbolic_link_to/etc/init.d
-  sudo: yes
+  become: yes
   file: path=/etc/init.d/{{ item }} state=link src=/usr/hdp/{{ hdp_version }}/hadoop-hdfs/etc/rc.d/init.d/{{ item }}
   with_items:
   - hadoop-hdfs-journalnode
   
 - name: create_hdfs_log_dir
-  sudo: yes
+  become: yes
   file: path={{ hdfs_log_dir }} state=directory mode=755 owner=hdfs group=hadoop 
 
 - name: copy_journalnode_defaults_file
-  sudo: yes
+  become: yes
   template: src=default_{{ item }}.j2 dest=/etc/default/{{ item }} mode=755 owner=hdfs group=hdfs
   with_items:
   - hadoop-hdfs-journalnode

--- a/playbooks/roles/journalnode/tasks/install.yml
+++ b/playbooks/roles/journalnode/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_journalnode_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hadoop-hdfs-journalnode

--- a/playbooks/roles/journalnode/tasks/main.yml
+++ b/playbooks/roles/journalnode/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,journalnode
-- include: config.yml tags=config,journalnode
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/journalnode_server_createdir/tasks/conf.yml
+++ b/playbooks/roles/journalnode_server_createdir/tasks/conf.yml
@@ -1,4 +1,4 @@
 - name: create_journalnode_data_dir
-  sudo: yes
+  become: yes
   file: path={{ dfs_journalnode_edits_dir }}/{{ dfs_nameservices }}/current/paxos state=directory owner=hdfs group=hdfs mode=755
   

--- a/playbooks/roles/journalnode_server_createdir/tasks/main.yml
+++ b/playbooks/roles/journalnode_server_createdir/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: conf.yml tags=conf,journalnode
+- include: conf.yml

--- a/playbooks/roles/journalnode_server_deletedata/tasks/delete.yml
+++ b/playbooks/roles/journalnode_server_deletedata/tasks/delete.yml
@@ -1,5 +1,5 @@
 - name: check_journalnode_edits_dirs
-  sudo: yes
+  become: yes
   shell: ls {{ dfs_journalnode_edits_dir }}/*
   register: check_journalnode_edits_dirs
   ignore_errors: true
@@ -7,11 +7,11 @@
   always_run: true
 
 - name: delete_journalnode_edits_dirs
-  sudo: yes
+  become: yes
   file: path={{ dfs_journalnode_edits_dir }} state=absent
   when: check_journalnode_edits_dirs.rc == 0
   
 - name: recreate_journalnode_edits_dirs
-  sudo: yes
+  become: yes
   file: path={{ dfs_journalnode_edits_dir }} state=directory mode=700 owner=hdfs group=hadoop
   when: check_journalnode_edits_dirs.rc == 0

--- a/playbooks/roles/journalnode_server_deletedata/tasks/main.yml
+++ b/playbooks/roles/journalnode_server_deletedata/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: delete.yml tags=delete,journalnode
+- include: delete.yml

--- a/playbooks/roles/mapreduce_history/tasks/config.yml
+++ b/playbooks/roles/mapreduce_history/tasks/config.yml
@@ -1,33 +1,33 @@
 - name: fix_init_scripts_2.2
-  sudo: yes
+  become: yes
   copy: src=init_{{ item }}_{{ hdp_version }} dest=/usr/hdp/{{ hdp_version }}/etc/rc.d/init.d/{{ item }} mode=755
   with_items:
   - hadoop-mapreduce-historyserver
   when: hdp_version == '2.2.0.0-2041'
   
 - name: create_symbolic_link_to/etc/init.d
-  sudo: yes
+  become: yes
   file: path=/etc/init.d/{{ item }} state=link src=/usr/hdp/{{ hdp_version }}/etc/rc.d/init.d/{{ item }}
   with_items:
   - hadoop-mapreduce-historyserver
   when: hdp_version == '2.2.0.0-2041'
   
 - name: create_symbolic_link_to/etc/init.d
-  sudo: yes
+  become: yes
   file: path=/etc/init.d/{{ item }} state=link src=/usr/hdp/{{ hdp_version }}/hadoop-mapreduce/etc/rc.d/init.d/{{ item }}
   with_items:
   - hadoop-mapreduce-historyserver
   when: hdp_version != '2.2.0.0-2041'
 
 - name: create_symbolic_link_to/usr/hdp/current/hadoop-mapreduce
-  sudo: yes
+  become: yes
   file: path=/usr/hdp/current/hadoop-mapreduce state=link src=/usr/hdp/{{ hdp_version }}/hadoop-mapreduce
   when: hdp_version != '2.2.0.0-2041'
 
 - name: create_pid_dir
-  sudo: yes
+  become: yes
   file: path={{ mapred_pid_dir }} state=directory mode=775 owner=mapred group=mapred
   
 - name: create_log_dir
-  sudo: yes
+  become: yes
   file: path={{ mapred_log_dir }} state=directory mode=755 owner=mapred group=hadoop 

--- a/playbooks/roles/mapreduce_history/tasks/install.yml
+++ b/playbooks/roles/mapreduce_history/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_mapreduce-historyserver_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hadoop-mapreduce-historyserver

--- a/playbooks/roles/mapreduce_history/tasks/main.yml
+++ b/playbooks/roles/mapreduce_history/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,mapreduce_history
-- include: config.yml tags=config,mapreduce_history
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/namenode/tasks/config.yml
+++ b/playbooks/roles/namenode/tasks/config.yml
@@ -1,5 +1,5 @@
 - name: create_namenode_data_dir
-  sudo: yes
+  become: yes
   file: path={{ item }} state=directory owner=hdfs group=hadoop mode=700
   with_items: dfs_namenode_name_dirs
 
@@ -11,41 +11,41 @@
   - hadoop-hdfs-zkfc
 
 - name: create_symbolic_link_to/etc/init.d
-  sudo: yes
+  become: yes
   file: path=/etc/init.d/{{ item }} state=link src=/usr/hdp/{{ hdp_version }}/hadoop-hdfs/etc/rc.d/init.d/{{ item }}
   with_items:
   - hadoop-hdfs-namenode
   - hadoop-hdfs-zkfc
 
 - name: create_symbolic_link_to/usr/hdp/current/hadoop
-  sudo: yes
+  become: yes
   file: path=/usr/hdp/current/hadoop state=link src=/etc/hadoop
 
 - name: create_symbolic_link_to/usr/hdp/current/hadoop-hdfs-zkfc
-  sudo: yes
+  become: yes
   file: path=/usr/hdp/current/hadoop-hdfs-zkfc state=link src=/usr/hdp/{{ hdp_version }}/hadoop-hdfs
 
 - name: deploy kick script for balancer.
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/usr/local/bin/{{ item }} mode=755
   with_items:
   - hdfs-balancer.sh
 
 - name: create_hdfs_log_dir
-  sudo: yes
+  become: yes
   file: path={{ hdfs_log_dir }} state=directory mode=755 owner=hdfs group=hadoop 
 
 - name: create_hdfs_pid_dir
-  sudo: yes
+  become: yes
   file: path={{ hdfs_pid_dir }} state=directory mode=755 owner=hdfs group=hdfs
 
 - name: create_jaas_conf
-  sudo: yes
+  become: yes
   template: src=jaas-hdfs.conf.j2 dest=/etc/hadoop/conf/jaas-hdfs.conf owner=hdfs group=hdfs
   when: kerberos_realm is defined
 
 - name: copy_defaults_file
-  sudo: yes
+  become: yes
   template: src=default_{{ item }}.j2 dest=/etc/default/{{ item }} mode=755 owner=hdfs group=hdfs
   with_items:
   - hadoop-hdfs-zkfc

--- a/playbooks/roles/namenode/tasks/install.yml
+++ b/playbooks/roles/namenode/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_namenode_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hadoop-hdfs-namenode

--- a/playbooks/roles/namenode/tasks/main.yml
+++ b/playbooks/roles/namenode/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,namenode
-- include: config.yml tags=config,namenode
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/namenode_bootstrapstandby/tasks/config.yml
+++ b/playbooks/roles/namenode_bootstrapstandby/tasks/config.yml
@@ -1,4 +1,4 @@
 - name: BootstrapStandby_namenode
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs namenode -bootstrapstandby

--- a/playbooks/roles/namenode_bootstrapstandby/tasks/main.yml
+++ b/playbooks/roles/namenode_bootstrapstandby/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: config.yml tags=config,namenode_bootstrapstandby
+- include: config.yml

--- a/playbooks/roles/namenode_format/tasks/config.yml
+++ b/playbooks/roles/namenode_format/tasks/config.yml
@@ -1,15 +1,15 @@
 - name: check_format_state
-  sudo: yes
+  become: yes
   stat: path={{ item }}/current
   with_items: dfs_namenode_name_dirs
 
 - name: FORMAT_namenode
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs namenode -format -force
 
 - name: FORMAT_ZKFC
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs zkfc -formatZK -force
   when: hadoop_namenode_servers|length > 1

--- a/playbooks/roles/namenode_format/tasks/main.yml
+++ b/playbooks/roles/namenode_format/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: config.yml tags=config,namenode_format
+- include: config.yml

--- a/playbooks/roles/os/tasks/kernel.yml
+++ b/playbooks/roles/os/tasks/kernel.yml
@@ -1,7 +1,7 @@
 - name: set_local_port_range
-  sudo: yes
+  become: yes
   lineinfile: dest=/etc/sysctl.conf line="net.ipv4.ip_local_port_range = {{ ipv4_ip_local_port_range_min }} {{ ipv4_ip_local_port_range_max }}" regexp="net.ipv4.ip_local_port_range"
     
 - name: set_somaxconn
-  sudo: yes
+  become: yes
   lineinfile: dest=/etc/sysctl.conf line="net.core.somaxconn = {{ net_core_somaxconn }}" regexp="net.core.somaxconn"

--- a/playbooks/roles/os/tasks/limits.yml
+++ b/playbooks/roles/os/tasks/limits.yml
@@ -1,15 +1,15 @@
 - name: set_nofile_soft_limit
-  sudo: yes
+  become: yes
   lineinfile: dest=/etc/security/limits.conf line="*    soft  nofile    {{ nofile_soft_limit }}" regexp="\* .*soft .*nofile .*"
 
 - name: set_nofile_hard_limit
-  sudo: yes
+  become: yes
   lineinfile: dest=/etc/security/limits.conf line="*    hard  nofile    {{ nofile_hard_limit }}" regexp="\* .*hard .*nofile .*"
     
 - name: set_core_soft_limit
-  sudo: yes
+  become: yes
   lineinfile: dest=/etc/security/limits.conf line="*    soft  core      {{ core_soft_limit }}" regexp="\* .*soft .*core .*"
 
 - name: set_core_hard_limit
-  sudo: yes
+  become: yes
   lineinfile: dest=/etc/security/limits.conf line="*    hard  core      {{ core_hard_limit }}" regexp="\* .*hard .*core .*"

--- a/playbooks/roles/os/tasks/main.yml
+++ b/playbooks/roles/os/tasks/main.yml
@@ -1,3 +1,3 @@
-- include: limits.yml tags=conf,os
-- include: thp.yml tags=conf,os
-- include: kernel.yml tages=conf,os
+- include: limits.yml
+- include: thp.yml
+- include: kernel.yml

--- a/playbooks/roles/os/tasks/thp.yml
+++ b/playbooks/roles/os/tasks/thp.yml
@@ -1,3 +1,3 @@
 - name: set_transparent_hugepage
-  sudo: yes
+  become: yes
   lineinfile: dest=/etc/rc.local line="echo never > /sys/kernel/mm/redhat_transparent_hugepage/defrag" regexp="echo never > /sys/kernel/mm/redhat_transparent_hugepage/defrag"

--- a/playbooks/roles/pig/tasks/config.yml
+++ b/playbooks/roles/pig/tasks/config.yml
@@ -1,5 +1,5 @@
 - name: copy_pig_conf
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/pig/conf/{{ item }} owner=root group=root mode=755
   with_items:
   - pig.properties

--- a/playbooks/roles/pig/tasks/install.yml
+++ b/playbooks/roles/pig/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_pig_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - pig

--- a/playbooks/roles/pig/tasks/main.yml
+++ b/playbooks/roles/pig/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,pig
-- include: config.yml tags=config,pig
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/presto_client/tasks/install.yml
+++ b/playbooks/roles/presto_client/tasks/install.yml
@@ -3,11 +3,11 @@
   register: check_presto_client_installed
   
 - name: create_prseto_client_install_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_client_install_path }} state=directory owner=presto group=presto mode=755
   
 - name: download_presto_by_wget
-  sudo: yes
+  become: yes
   shell: wget --no-verbose {{ presto_client_download_url }}/presto-cli-{{ presto_version }}-executable.jar -O presto-cli-{{ presto_version }}-executable.jar chdir={{ presto_client_install_path }} creates={{ presto_client_install_path }}/presto-cli-{{ presto_version }}-executable.jar
   when: not check_presto_client_installed.stat.exists
   ignore_errors: yes
@@ -23,5 +23,5 @@
   when: not check_presto_client_installed.stat.exists and md5sum_presto_client.stdout.find('{{ presto_client_md5sum }}')
 
 - name: change_mode_presto_client
-  sudo: yes
+  become: yes
   file: path={{ presto_client_install_path }}/presto-cli-{{ presto_version }}-executable.jar owner=presto group=presto mode=755

--- a/playbooks/roles/presto_client/tasks/main.yml
+++ b/playbooks/roles/presto_client/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: install.yml tags=install,presto
+- include: install.yml

--- a/playbooks/roles/presto_coordinator/tasks/catalog.yml
+++ b/playbooks/roles/presto_coordinator/tasks/catalog.yml
@@ -1,5 +1,5 @@
 - name: copy_presto_catalog_file
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/presto/conf/catalog/{{ item }} 
   with_items:
   - hive.properties

--- a/playbooks/roles/presto_coordinator/tasks/config.yml
+++ b/playbooks/roles/presto_coordinator/tasks/config.yml
@@ -1,13 +1,13 @@
 - name: create_presto_conf_dir
-  sudo: yes
+  become: yes
   file: path=/etc/presto/conf state=directory owner=root group=root mode=755
   
 - name: create_symbolic_link_to_presto_conf_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_install_path }}/presto-server-{{ presto_version }}/etc state=link src=/etc/presto/conf
   
 - name: copy_presto_conf_files
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/presto/conf/{{ item }} owner=root group=root mode=755
   with_items:
   - node.properties
@@ -16,43 +16,43 @@
   - log.properties
   
 - name: create_catalog_dir
-  sudo: yes
+  become: yes
   file: path=/etc/presto/conf/catalog state=directory owner=root group=root mode=755
   
 - name: create_presto_data_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_data_dir }} state=directory owner=presto group=hadoop mode=755
   
 - name: create_presto_log_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_log_dir }} state=directory owner=presto group=hadoop mode=755
 
 - name: create_presto_var_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_data_dir }}/var state=directory
   
 - name: create_symbolic_link_to_presto_log_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_data_dir }}/var/log state=link src={{ presto_log_dir }}
 
 - name: create_presto_pid_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_pid_dir }} state=directory owner=presto group=presto mode=755
   
 - name: create_symbolic_link_to_presto_pid_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_data_dir }}/var/run state=link src={{ presto_pid_dir }}
 
 - name: copy_launcher_script
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest={{ presto_install_path }}/presto-server-{{ presto_version }}/bin/{{ item }} owner=root group=root mode=755
   with_items:
   - launcher
   
 - name: set_PRESTO_HOME
-  sudo: yes
+  become: yes
   template: src=presto.sh.j2 dest=/etc/profile.d/presto.sh owner=root group=root mode=644
     
 - name: copy_sudoers_conf_of_PRESTO_HOME
-  sudo: yes
+  become: yes
   copy: src=env_keep_prestohome dest=/etc/sudoers.d mode=440 owner=root

--- a/playbooks/roles/presto_coordinator/tasks/install.yml
+++ b/playbooks/roles/presto_coordinator/tasks/install.yml
@@ -18,6 +18,6 @@
   when: not check_presto_installed.stat.exists and md5sum_presto.stdout.find('{{ presto_md5sum }}')
 
 - name: umcompressed_presto.tar.gz_file
-  sudo: yes
+  become: yes
   shell: tar zxvf {{ presto_tmp_path }}/presto-server-{{ presto_version}}.tar.gz -C {{ presto_install_path }}
   when: not check_presto_installed.stat.exists

--- a/playbooks/roles/presto_coordinator/tasks/main.yml
+++ b/playbooks/roles/presto_coordinator/tasks/main.yml
@@ -1,3 +1,3 @@
-- include: install.yml tags=install,presto
-- include: config.yml tags=config,presto
-- include: catalog.yml tags=config.presto
+- include: install.yml
+- include: config.yml
+- include: catalog.yml

--- a/playbooks/roles/presto_user/tasks/main.yml
+++ b/playbooks/roles/presto_user/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: user.yml tags=user,presto
+- include: user.yml

--- a/playbooks/roles/presto_user/tasks/user.yml
+++ b/playbooks/roles/presto_user/tasks/user.yml
@@ -1,3 +1,3 @@
 - name: create_presto_user
-  sudo: yes
+  become: yes
   user: name=presto createhome=no uid={{ presto_user_id }}

--- a/playbooks/roles/presto_worker/tasks/catalog.yml
+++ b/playbooks/roles/presto_worker/tasks/catalog.yml
@@ -1,5 +1,5 @@
 - name: copy_presto_catalog_file
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/presto/conf/catalog/{{ item }} 
   with_items:
   - hive.properties

--- a/playbooks/roles/presto_worker/tasks/config.yml
+++ b/playbooks/roles/presto_worker/tasks/config.yml
@@ -1,13 +1,13 @@
 - name: create_presto_conf_dir
-  sudo: yes
+  become: yes
   file: path=/etc/presto/conf state=directory owner=root group=root mode=755
   
 - name: create_symbolic_link_to_presto_conf_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_install_path }}/presto-server-{{ presto_version }}/etc state=link src=/etc/presto/conf
   
 - name: copy_presto_conf_files
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/presto/conf/{{ item }} owner=root group=root mode=755
   with_items:
   - node.properties
@@ -16,43 +16,43 @@
   - log.properties
   
 - name: create_catalog_dir
-  sudo: yes
+  become: yes
   file: path=/etc/presto/conf/catalog state=directory owner=root group=root mode=755
   
 - name: create_presto_data_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_data_dir }} state=directory owner=presto group=hadoop mode=755
   
 - name: create_presto_log_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_log_dir }} state=directory owner=presto group=hadoop mode=755
 
 - name: create_presto_var_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_data_dir }}/var state=directory owner=presto group=hadoop mode=755
   
 - name: create_symbolic_link_to_presto_log_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_data_dir }}/var/log state=link src={{ presto_log_dir }}
   
 - name: create_presto_pid_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_pid_dir }} state=directory owner=presto group=presto mode=755
   
 - name: create_symbolic_link_to_presto_pid_dir
-  sudo: yes
+  become: yes
   file: path={{ presto_data_dir }}/var/run state=link src={{ presto_pid_dir }}
 
 - name: copy_launcher_script
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest={{ presto_install_path }}/presto-server-{{ presto_version }}/bin/{{ item }} owner=root group=root mode=755
   with_items:
   - launcher
   
 - name: set_PRESTO_HOME
-  sudo: yes
+  become: yes
   template: src=presto.sh.j2 dest=/etc/profile.d/presto.sh owner=root group=root mode=644
     
 - name: copy_sudoers_conf_of_PRESTO_HOME
-  sudo: yes
+  become: yes
   copy: src=env_keep_prestohome dest=/etc/sudoers.d mode=440 owner=root

--- a/playbooks/roles/presto_worker/tasks/install.yml
+++ b/playbooks/roles/presto_worker/tasks/install.yml
@@ -18,6 +18,6 @@
   when: not check_presto_installed.stat.exists and md5sum_presto.stdout.find('{{ presto_md5sum }}')
 
 - name: umcompressed_presto.tar.gz_file
-  sudo: yes
+  become: yes
   shell: tar zxvf {{ presto_tmp_path }}/presto-server-{{ presto_version}}.tar.gz -C {{ presto_install_path }}
   when: not check_presto_installed.stat.exists

--- a/playbooks/roles/presto_worker/tasks/main.yml
+++ b/playbooks/roles/presto_worker/tasks/main.yml
@@ -1,3 +1,3 @@
-- include: install.yml tags=install,presto
-- include: config.yml tags=config,presto
-- include: catalog.yml tags=config.presto
+- include: install.yml
+- include: config.yml
+- include: catalog.yml

--- a/playbooks/roles/resourcemanager/tasks/config.yml
+++ b/playbooks/roles/resourcemanager/tasks/config.yml
@@ -5,21 +5,21 @@
   - hadoop-yarn-resourcemanager
   
 - name: create_symbolic_link_to/etc/init.d
-  sudo: yes
+  become: yes
   file: path=/etc/init.d/{{ item }} state=link src=/usr/hdp/{{ hdp_version }}/hadoop-yarn/etc/rc.d/init.d/{{ item }}
   with_items:
   - hadoop-yarn-resourcemanager
 
 - name: create_yarn_pid_dir
-  sudo: yes
+  become: yes
   file: path={{ yarn_pid_dir }} state=directory mode=755 owner=yarn group=yarn
   
 - name: create_yarn_log_dir
-  sudo: yes
+  become: yes
   file: path={{ yarn_log_dir }} state=directory mode=755 owner=yarn group=hadoop
 
 - name: copy_default_file
-  sudo: yes
+  become: yes
   template: src=default_{{ item }}.j2 dest=/etc/default/{{ item }} mode=755 owner=root group=root 
   with_items:
   - hadoop-yarn-resourcemanager

--- a/playbooks/roles/resourcemanager/tasks/install.yml
+++ b/playbooks/roles/resourcemanager/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_resourcemanager_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hadoop-yarn-resourcemanager

--- a/playbooks/roles/resourcemanager/tasks/main.yml
+++ b/playbooks/roles/resourcemanager/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,resourcemanager
-- include: config.yml tags=config,resourcemanager
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/slavenode/tasks/config.yml
+++ b/playbooks/roles/slavenode/tasks/config.yml
@@ -1,5 +1,5 @@
 - name: create_datanode_data_dir
-  sudo: yes
+  become: yes
   file: path={{ item }} state=directory owner=hdfs group=hadoop mode=700
   with_items: dfs_datanode_data_dirs
 
@@ -11,30 +11,30 @@
   - { name: hadoop-yarn-nodemanager, path: hadoop-yarn }
   
 - name: create_symbolic_link_to/etc/init.d
-  sudo: yes
+  become: yes
   file: path=/etc/init.d/{{ item.name }} state=link src=/usr/hdp/{{ hdp_version }}/{{ item.path }}/etc/rc.d/init.d/{{ item.name }}
   with_items:
   - { name: hadoop-hdfs-datanode, path: hadoop-hdfs }
   - { name: hadoop-yarn-nodemanager, path: hadoop-yarn }
   
 - name: create_holder_directory_for_hadoop_tmp_dir
-  sudo: yes
+  become: yes
   file: path={{ hadoop_tmp_dir[0:hadoop_tmp_dir.rfind('/')] }} state=directory mode=755 owner=yarn group=yarn
   
 - name: create_yarn_pid_dir
-  sudo: yes
+  become: yes
   file: path={{ yarn_pid_dir }} state=directory mode=755 owner=yarn group=yarn
 
 - name: create_hdfs_log_dir
-  sudo: yes
+  become: yes
   file: path={{ hdfs_log_dir }} state=directory mode=755 owner=hdfs group=hadoop 
   
 - name: create_yarn_log_dir
-  sudo: yes
+  become: yes
   file: path={{ yarn_log_dir }} state=directory mode=755 owner=yarn group=hadoop
 
 - name: copy_defaults_file
-  sudo: yes
+  become: yes
   template: src=default_{{ item }}.j2 dest=/etc/default/{{ item }} mode=755 owner=root group=root
   with_items:
   - hadoop-hdfs-datanode

--- a/playbooks/roles/slavenode/tasks/install.yml
+++ b/playbooks/roles/slavenode/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_slavenode_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hadoop-hdfs-datanode

--- a/playbooks/roles/slavenode/tasks/main.yml
+++ b/playbooks/roles/slavenode/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,slavenode
-- include: config.yml tags=config,slavenode
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/spark/tasks/config.yml
+++ b/playbooks/roles/spark/tasks/config.yml
@@ -1,23 +1,23 @@
 - name: set_SPARK_HOME
-  sudo: yes
+  become: yes
   template: src=spark.sh.j2 dest=/etc/profile.d/spark.sh owner=root group=root mode=644
   
 - name: create_spark_conf_dir
-  sudo: yes
+  become: yes
   file: path=/etc/spark/ state=directory owner=root group=root mode=755
   
 - name: create_symbolic_link_to_spark_conf_dir
-  sudo: yes
+  become: yes
   file: path=/etc/spark/conf state=link src={{ spark_install_path }}/spark-{{ spark_version }}-bin-{{ spark_hadoop_version }}/conf
   when: hdp_version == '2.2.0.0-2041'
 
 - include: principal.yml
-  sudo: yes
+  become: yes
   vars: { kerberos_princ_username: spark, kerberos_princ_keytab_path: /etc/spark/conf/spark.keytab, kerberos_princ_keytab_owner: spark }
   when: kerberos_realm is defined
 
 - name: copy_spark_conf_files
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/spark/conf/{{ item }} owner=root group=root mode=755
   with_items:
   - spark-defaults.conf
@@ -27,5 +27,5 @@
   - fairscheduler.xml
 
 - name: copy_sudoers_conf_of_SPARK_HOME
-  sudo: yes
+  become: yes
   copy: src=env_keep_sparkhome dest=/etc/sudoers.d/ owner=root mode=440   

--- a/playbooks/roles/spark/tasks/install-tarball.yml
+++ b/playbooks/roles/spark/tasks/install-tarball.yml
@@ -19,16 +19,16 @@
   when: not check_spark_installed.stat.exists and md5sum_spark.stdout.find('{{ spark_md5sum }}')
 
 - name: umcompressed_spark.tgz_file
-  sudo: yes
+  become: yes
   shell: tar zxvf {{ spark_tmp_path }}/spark-{{ spark_version}}-bin-{{ spark_hadoop_version }}.tgz -C {{ spark_install_path }}
   when: not check_spark_installed.stat.exists
 
 - name: change_spark_dir_onwer_to_root
-  sudo: yes
+  become: yes
   file: path={{ spark_install_path }} owner=root group=root recurse=yes state=directory
   when: not check_spark_installed.stat.exists
 
 - name: delete_spark_logs_dir
-  sudo: yes
+  become: yes
   shell: rm -rf {{ spark_install_path }}/spark-{{ spark_version }}-bin-{{ spark_hadoop_version }}/logs
   when: not check_spark_installed.stat.exists

--- a/playbooks/roles/spark/tasks/install.yml
+++ b/playbooks/roles/spark/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_spark_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - spark

--- a/playbooks/roles/spark/tasks/main.yml
+++ b/playbooks/roles/spark/tasks/main.yml
@@ -1,6 +1,6 @@
-- include: install-tarball.yml tags=install,spark
+- include: install-tarball.yml
   when: hdp_version == '2.2.0.0-2041'
-- include: install.yml tags=install,spark
+- include: install.yml
   when: hdp_version != '2.2.0.0-2041'
 
-- include: config.yml tags=config,spark
+- include: config.yml

--- a/playbooks/roles/spark_history/tasks/config.yml
+++ b/playbooks/roles/spark_history/tasks/config.yml
@@ -1,25 +1,25 @@
 - name: create_spark_log_dir
-  sudo: yes
+  become: yes
   file: path={{ spark_log_dir }} state=directory owner=spark group=hadoop mode=755
     
 - name: create_symbolic_link_to_spark_log_dir
-  sudo: yes
+  become: yes
   file: path={{ spark_install_path }}/spark-{{ spark_version }}-bin-{{ spark_hadoop_version }}/logs state=link src={{ spark_log_dir }}
   register: md5sum_spark
   when: hdp_version == '2.2.0.0-2041'
     
 - name: remove_spark_log_dir
-  sudo: yes
+  become: yes
   file: path=/usr/hdp/{{ hdp_version }}/spark/logs state=absent
   when: hdp_version != '2.2.0.0-2041'
     
 - name: create_symbolic_link_to_spark_log_dir
-  sudo: yes
+  become: yes
   file: path=/usr/hdp/{{ hdp_version }}/spark/logs state=link src={{ spark_log_dir }}
   register: md5sum_spark
   when: hdp_version != '2.2.0.0-2041'
 
 - name: create_spark_pid_dir
-  sudo: yes
+  become: yes
   file: path={{ spark_pid_dir }} state=directory owner=spark group=spark mode=775
   when: hdp_version == '2.2.0.0-2041'

--- a/playbooks/roles/spark_history/tasks/main.yml
+++ b/playbooks/roles/spark_history/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: config.yml tags=config,spark_history
+- include: config.yml

--- a/playbooks/roles/spark_user/tasks/main.yml
+++ b/playbooks/roles/spark_user/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: user.yml tags=user,presto
+- include: user.yml

--- a/playbooks/roles/spark_user/tasks/user.yml
+++ b/playbooks/roles/spark_user/tasks/user.yml
@@ -1,3 +1,3 @@
 - name: create_spark_user
-  sudo: yes
+  become: yes
   user: name=spark createhome=no uid={{ spark_user_id }}

--- a/playbooks/roles/storm/tasks/config.yml
+++ b/playbooks/roles/storm/tasks/config.yml
@@ -1,9 +1,9 @@
 - name: create_storm_data_dir
-  sudo: yes
+  become: yes
   file: path={{ storm_data_dir }} state=directory owner=storm group=root mode=755
 
 - name: copy_init_scripts
-  sudo: yes
+  become: yes
   copy: src={{ item }} dest=/etc/rc.d/init.d/{{ item }} owner=root group=root mode=755
   with_items:
   - storm-nimbus
@@ -12,13 +12,13 @@
   - storm-drpc
 
 - name: fix_start_scripts
-  sudo: yes
+  become: yes
   copy: src={{ item }} dest=/usr/hdp/current/storm-client/bin/{{ item }} owner=root group=root mode=644
   with_items:
   - storm.py
 
 - name: copy_storom_conf_files
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/storm/conf/{{ item }} owner=root group=root mode=644
   with_items:
   - storm-env.sh
@@ -27,9 +27,9 @@
   - storm_env.ini
   
 - name: create_storm_log_dir
-  sudo: yes
+  become: yes
   file: path=/var/log/storm state=directory owner=storm group=storm mode=755
 
 - name: create_storm_pid_dir
-  sudo: yes
+  become: yes
   file: path=/var/run/storm state=directory owner=storm group=storm mode=755

--- a/playbooks/roles/storm/tasks/install.yml
+++ b/playbooks/roles/storm/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_storm_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - storm

--- a/playbooks/roles/storm/tasks/main.yml
+++ b/playbooks/roles/storm/tasks/main.yml
@@ -1,3 +1,3 @@
-- include: user.yml tags=install,storm
-- include: install.yml tags=install,storm
-- include: config.yml tags=config,storm
+- include: user.yml
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/storm/tasks/user.yml
+++ b/playbooks/roles/storm/tasks/user.yml
@@ -1,7 +1,7 @@
 - name: create_storm_group
-  sudo: yes
+  become: yes
   group: name=storm gid={{ storm_group_id }}
 
 - name: create_storm_user
-  sudo: yes
+  become: yes
   user: name=storm createhome=no uid={{ storm_user_id }} group=storm groups=storm

--- a/playbooks/roles/swimlane/tasks/conf.yml
+++ b/playbooks/roles/swimlane/tasks/conf.yml
@@ -1,8 +1,8 @@
 - name: check_swimlane_installed
-  sudo: yes
+  become: yes
   file: path={{ swimlane_install_path }}/apache-tez-{{ swimlane_tez_version }}-src/tez-tools/swimlanes state=directory mode=777 owner=yarn group=hadoop
   
 - name: create_swimlanes_directory
-  sudo: yes
+  become: yes
   file: path=/var/www/html/swimlanes state=directory owner=yarn group=hadoop
   

--- a/playbooks/roles/swimlane/tasks/install-tarball.yml
+++ b/playbooks/roles/swimlane/tasks/install-tarball.yml
@@ -19,10 +19,10 @@
   when: not check_swimlane_installed.stat.exists and md5sum_swimlane.stdout.find('{{ swimlane_md5sum }}')
   
 - name: umcompressed_swimlane_file
-  sudo: yes
+  become: yes
   shell: tar zxf {{ swimlane_tmp_path }}/apache-tez-{{ swimlane_tez_version }}-src.tar.gz -C {{ swimlane_install_path }}
   when: not check_swimlane_installed.stat.exists
 
 - name: install_httpd
-  sudo: yes
+  become: yes
   yum: name=httpd state=installed

--- a/playbooks/roles/swimlane/tasks/main.yml
+++ b/playbooks/roles/swimlane/tasks/main.yml
@@ -1,7 +1,7 @@
-- include: install-tarball.yml tags=install,swimlane
+- include: install-tarball.yml
   when: hdp_version == '2.2.0.0-2041'
 
-- include: install-github.yml tags=install,swimlane
+- include: install-github.yml
   when: hdp_version != '2.2.0.0-2041'
 
-- include: conf.yml tags=conf,swimlane
+- include: conf.yml

--- a/playbooks/roles/tez/tasks/config.yml
+++ b/playbooks/roles/tez/tasks/config.yml
@@ -1,9 +1,9 @@
 - name: create_tez_conf_dir
-  sudo: yes
+  become: yes
   file: path=/etc/tez/conf state=directory owner=root group=hadoop mode=755
 
 - name: copy_tez_conf
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/tez/conf/{{ item }} owner=root group=hadoop mode=755
   with_items:
   - tez-site.xml

--- a/playbooks/roles/tez/tasks/install.yml
+++ b/playbooks/roles/tez/tasks/install.yml
@@ -1,12 +1,12 @@
 - name: install_tez_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - tez
 
 - name: check_tez_packages_on_HDFS
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -ls {{ tez_hdfs_dir }}/tez.tar.gz
   register: check_tez_installed_on_hdfs
   ignore_errors: yes
@@ -14,21 +14,21 @@
   always_run: true
   
 - name: copy_tez_packages_to_HDFS
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -copyFromLocal /usr/hdp/current/tez-client/lib/tez.tar.gz {{ tez_hdfs_dir }}
   register: copy_tez_packages_to_HDFS
   when: check_tez_installed_on_hdfs.rc != 0
   
 - name: change_owner_of_tez_packages
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -chown -R hdfs:hadoop {{ tez_hdfs_dir }}
   when: check_tez_installed_on_hdfs.rc != 0
   
 - name: change_mode_of_tez_packages
-  sudo: yes
-  sudo_user: hdfs
+  become: yes
+  become_user: hdfs
   shell: hdfs dfs -chmod -R 555 {{ tez_hdfs_dir }}
   when: check_tez_installed_on_hdfs.rc != 0
   

--- a/playbooks/roles/tez/tasks/main.yml
+++ b/playbooks/roles/tez/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,tez
-- include: config.yml tags=config,tez
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/timelineservice/tasks/config.yml
+++ b/playbooks/roles/timelineservice/tasks/config.yml
@@ -5,29 +5,29 @@
   - hadoop-yarn-timelineserver
   
 - name: create_symbolic_link_to/etc/init.d
-  sudo: yes
+  become: yes
   file: path=/etc/init.d/{{ item }} state=link src=/usr/hdp/{{ hdp_version }}/hadoop-yarn/etc/rc.d/init.d/{{ item }}
   with_items:
   - hadoop-yarn-timelineserver
 
 - name: create_symbolic_link_to/usr/hdp/current/hadoop-yarn
-  sudo: yes
+  become: yes
   file: path=/usr/hdp/current/hadoop-yarn state=link src=/usr/hdp/{{ hdp_version }}/hadoop-yarn
 
 - name: create_yarn_pid_dir
-  sudo: yes
+  become: yes
   file: path={{ yarn_pid_dir }} state=directory mode=755 owner=yarn group=yarn
   
 - name: create_yarn_log_dir
-  sudo: yes
+  become: yes
   file: path={{ yarn_log_dir }} state=directory mode=755 owner=yarn group=hadoop
   
 - name: create_timeline_dir
-  sudo: yes
+  become: yes
   file: path={{ hadoop_tmp_dir[0:hadoop_tmp_dir.rfind('/')] }}/hadoop-yarn/yarn/timeline state=directory mode=755 owner=yarn group=yarn
 
 - name: copy_default_file
-  sudo: yes
+  become: yes
   template: src=default_{{ item }}.j2 dest=/etc/default/{{ item }} mode=755 owner=root group=root 
   with_items:
   - hadoop-yarn-timelineserver

--- a/playbooks/roles/timelineservice/tasks/install.yml
+++ b/playbooks/roles/timelineservice/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_timelineserver_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - hadoop-yarn-timelineserver

--- a/playbooks/roles/timelineservice/tasks/main.yml
+++ b/playbooks/roles/timelineservice/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,resourcemanager
-- include: config.yml tags=config,resourcemanager
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/zookeeper_server/tasks/config.yml
+++ b/playbooks/roles/zookeeper_server/tasks/config.yml
@@ -1,78 +1,78 @@
 - name: create_config_dir
-  sudo: yes
+  become: yes
   file: path=/etc/zookeeper/conf state=directory mode=755
 
 - include: principal.yml
-  sudo: yes
+  become: yes
   vars: { kerberos_princ_username: zookeeper, kerberos_princ_keytab_path: /etc/zookeeper/conf/zookeeper.keytab, kerberos_princ_keytab_owner: zookeeper }
   when: kerberos_realm is defined
 
 - name: copy_jaas_conf
-  sudo: yes
+  become: yes
   template: src=jaas.conf.j2 dest=/etc/zookeeper/conf/jaas.conf
   when: kerberos_realm is defined
 
 - name: copy_config_files
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/zookeeper/conf/{{ item }}
   with_items:
   - zoo.cfg
   - log4j.properties
   
 - name: create_zookeeper_data_dir
-  sudo: yes
+  become: yes
   file: path={{ zookeeper_data_dir }} state=directory owner=zookeeper group=hadoop mode=755
   when: hdp_version == '2.2.0.0-2041'
 
 - name: create_zookeeper_data_dir
-  sudo: yes
+  become: yes
   file: path={{ zookeeper_data_dir }} state=directory owner=zookeeper group=zookeeper mode=755
   when: hdp_version != '2.2.0.0-2041'
 
 - name: copy_myid_file
-  sudo: yes
+  become: yes
   template: src=myid.j2 dest={{zookeeper_data_dir}}/myid
 
 - name: create_symbolic_link_to_/usr/bin
-  sudo: yes
+  become: yes
   file: path=/usr/bin/{{ item }} state=link src=/usr/hdp/current/zookeeper-client/bin/{{ item }}
   with_items:
   - zookeeper-server
   - zookeeper-client
 
 - name: fix_init_scripts
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/usr/hdp/{{ hdp_version }}/etc/rc.d/init.d/{{ item }} mode=755
   with_items:
   - zookeeper-server
   when: hdp_version == '2.2.0.0-2041'
   
 - name: create_symbolic_link_to_/etc/init.d
-  sudo: yes
+  become: yes
   file: path=/etc/init.d/{{ item }} state=link src=/usr/hdp/{{ hdp_version }}/etc/rc.d/init.d/{{ item }}
   with_items:
   - zookeeper-server
   when: hdp_version == '2.2.0.0-2041'
   
 - name: create_symbolic_link_to_/etc/init.d
-  sudo: yes
+  become: yes
   file: path=/etc/init.d/{{ item }} state=link src=/usr/hdp/{{ hdp_version }}/zookeeper/etc/rc.d/init.d/{{ item }}
   with_items:
   - zookeeper-server
   when: hdp_version != '2.2.0.0-2041'
  
 - name: copy_zookeeper-env.sh
-  sudo: yes
+  become: yes
   template: src={{ item }}.j2 dest=/etc/zookeeper/conf/{{ item }}
   with_items:
   - zookeeper-env.sh
 
 - name: create_zookeeper_log_dir
-  sudo: yes
+  become: yes
   file: path={{ zookeeper_log_dir }} state=directory owner=zookeeper group=hadoop mode=755
   when: hdp_version == '2.2.0.0-2041'
 
 - name: create_zookeeper_log_dir
-  sudo: yes
+  become: yes
   file: path={{ zookeeper_log_dir }} state=directory owner=zookeeper group=zookeeper mode=755
   when: hdp_version != '2.2.0.0-2041'

--- a/playbooks/roles/zookeeper_server/tasks/install.yml
+++ b/playbooks/roles/zookeeper_server/tasks/install.yml
@@ -1,5 +1,5 @@
 - name: install_zookeeper-server_packages
-  sudo: yes
+  become: yes
   yum: name={{ item }} state=installed
   with_items:
   - zookeeper-server

--- a/playbooks/roles/zookeeper_server/tasks/main.yml
+++ b/playbooks/roles/zookeeper_server/tasks/main.yml
@@ -1,2 +1,2 @@
-- include: install.yml tags=install,zookeeper
-- include: config.yml tags=config,zookeeper
+- include: install.yml
+- include: config.yml

--- a/playbooks/roles/zookeeper_server_deletedata/tasks/main.yml
+++ b/playbooks/roles/zookeeper_server_deletedata/tasks/main.yml
@@ -1,1 +1,1 @@
-- include: delete.yml tags=delete,zookeeper
+- include: delete.yml

--- a/playbooks/start_datanode.yml
+++ b/playbooks/start_datanode.yml
@@ -1,7 +1,7 @@
 ## 前提1: NameNodeの少なくとも片系が起動して、Activeとなっていること
 
 - hosts: hadoop_slavenode
-  sudo: yes
+  become: yes
   tasks:
     - name: start_hadoop-hdfs-datanode
       service: name=hadoop-hdfs-datanode state=started

--- a/playbooks/start_hbase_master.yml
+++ b/playbooks/start_hbase_master.yml
@@ -3,7 +3,7 @@
 ## 前提3: 利用予定のRegionServerが全台起動していること
 
 - hosts: hadoop_hbase_master
-  sudo: yes
+  become: yes
   tasks:
     - name: start_hbase-master
       service: name=hbase-master state=started

--- a/playbooks/start_hbase_regionserver.yml
+++ b/playbooks/start_hbase_regionserver.yml
@@ -2,7 +2,7 @@
 ## 前提2: HDFSが利用可能(正常に読み書きできる)であること
 
 - hosts: hadoop_hbase_regionserver
-  sudo: yes
+  become: yes
   tasks:
     - name: start_hbase-regionserver
       service: name=hbase-regionserver state=started

--- a/playbooks/start_hcatalog.yml
+++ b/playbooks/start_hcatalog.yml
@@ -1,6 +1,6 @@
 - hosts: hadoop_hive
-  sudo: yes
-  sudo_user: hive
+  become: yes
+  become_user: hive
   tasks:
     - name: check_status_hcatalog
       shell: '[ -s /usr/hdp/current/hive-webhcat/var/log/hcat.pid ] && [ -x /proc/$(cat /usr/hdp/current/hive-webhcat/var/log/hcat.pid) ]'

--- a/playbooks/start_httpfs.yml
+++ b/playbooks/start_httpfs.yml
@@ -1,5 +1,5 @@
 - hosts: hadoop_httpfs
-  sudo: yes
+  become: yes
   tasks:
     - name: start_hadoop-httpfs
       service: name=hadoop-httpfs state=started

--- a/playbooks/start_hue.yml
+++ b/playbooks/start_hue.yml
@@ -1,5 +1,5 @@
 - hosts: hadoop_hue
-  sudo: yes
+  become: yes
   tasks:
     - name: start_hue_server
       service: name=hue state=started

--- a/playbooks/start_journalnode.yml
+++ b/playbooks/start_journalnode.yml
@@ -1,5 +1,5 @@
 - hosts: hadoop_journalnode
-  sudo: yes
+  become: yes
   tasks:
     - name: start_hadoop-hdfs-journalnode
       service: name=hadoop-hdfs-journalnode state=started

--- a/playbooks/start_mapreduce_historyserver.yml
+++ b/playbooks/start_mapreduce_historyserver.yml
@@ -1,5 +1,5 @@
 - hosts: hadoop_mapreduce_historyserver
-  sudo: yes
+  become: yes
   tasks:
     - name: start_mapreduce-historyserver
       service: name=hadoop-mapreduce-historyserver state=started

--- a/playbooks/start_namenode.yml
+++ b/playbooks/start_namenode.yml
@@ -2,7 +2,7 @@
 ## 前提2: ZooKeeperとJournalNodeがそれぞれ過半数以上起動していること
 
 - hosts: hadoop_namenode
-  sudo: yes
+  become: yes
   tasks:
     - name: start_hadoop-hdfs-zkfc
       service: name=hadoop-hdfs-zkfc state=started

--- a/playbooks/start_nodemanager.yml
+++ b/playbooks/start_nodemanager.yml
@@ -1,7 +1,7 @@
 ## 前提1: ResourceManagerの少なくとも片系が起動して、Activeとなっていること
 
 - hosts: hadoop_slavenode
-  sudo: yes
+  become: yes
   tasks:
     - name: start_hadoop-yarn-nodemanager
       service: name=hadoop-yarn-nodemanager state=started

--- a/playbooks/start_resourcemanager.yml
+++ b/playbooks/start_resourcemanager.yml
@@ -1,5 +1,5 @@
 - hosts: hadoop_resourcemanager
-  sudo: yes
+  become: yes
   tasks:
     - name: start_hadoop-yarn-resourcemanager
       service: name=hadoop-yarn-resourcemanager state=started

--- a/playbooks/start_spark_historyserver.yml
+++ b/playbooks/start_spark_historyserver.yml
@@ -1,8 +1,8 @@
 ## 前提1: HDFSが利用可能(正常に読み書きできる)であること
 
 - hosts: hadoop_spark_history
-  sudo: yes
-  sudo_user: spark
+  become: yes
+  become_user: spark
   tasks:
     - name: check_status_spark_history_server
       shell: '[ -s ${SPARK_PID_DIR}/spark-spark-org.apache.spark.deploy.history.HistoryServer-1.pid ] && [ -x /proc/$(cat ${SPARK_PID_DIR}/spark-spark-org.apache.spark.deploy.history.HistoryServer-1.pid ) ]'

--- a/playbooks/start_timelineservice.yml
+++ b/playbooks/start_timelineservice.yml
@@ -1,5 +1,5 @@
 - hosts: hadoop_timelineservice
-  sudo: yes
+  become: yes
   tasks:
     - name: start_hadoop-yarn-timelineserver
       service: name=hadoop-yarn-timelineserver state=started

--- a/playbooks/start_zookeeper-server.yml
+++ b/playbooks/start_zookeeper-server.yml
@@ -1,5 +1,5 @@
 - hosts: hadoop_zookeeperserver
-  sudo: yes
+  become: yes
   tasks:
     - name: start_zookeeper-server
       service: name=zookeeper-server state=started

--- a/playbooks/stop_datanode.yml
+++ b/playbooks/stop_datanode.yml
@@ -1,7 +1,7 @@
 ## 前提1: NameNode, ZKFCが停止していること
 
 - hosts: hadoop_slavenode
-  sudo: yes
+  become: yes
   tasks:
     - name: stop_hadoop-hdfs-datanode
       service: name=hadoop-hdfs-datanode state=stopped

--- a/playbooks/stop_hbase_master.yml
+++ b/playbooks/stop_hbase_master.yml
@@ -1,7 +1,7 @@
 ## 前提1: HBase上でクエリ等の処理が動作していないこと
 
 - hosts: hadoop_hbase_master
-  sudo: yes
+  become: yes
   tasks:
     - name: stop_hbase-master
       service: name=hbase-master state=stopped

--- a/playbooks/stop_hbase_regionserver.yml
+++ b/playbooks/stop_hbase_regionserver.yml
@@ -2,7 +2,7 @@
 ## リージョンのスプリット等が発生するため、RegionServerから停止させてはならない
 
 - hosts: hadoop_hbase_regionserver
-  sudo: yes
+  become: yes
   tasks:
     - name: stop_hbase-regionserver
       service: name=hbase-regionserver state=stopped

--- a/playbooks/stop_hcatalog.yml
+++ b/playbooks/stop_hcatalog.yml
@@ -1,6 +1,6 @@
 - hosts: hadoop_hive
-  sudo: yes
-  sudo_user: hive
+  become: yes
+  become_user: hive
   tasks:
     - name: check_status_hcatalog
       shell: '[ -s /usr/hdp/current/hive-webhcat/var/log/hcat.pid ] && [ -x /proc/$(cat /usr/hdp/current/hive-webhcat/var/log/hcat.pid) ]'

--- a/playbooks/stop_journalnode.yml
+++ b/playbooks/stop_journalnode.yml
@@ -1,7 +1,7 @@
 ## 前提1: NameNode, ZKFC, DataNodeが全て停止していること
 
 - hosts: hadoop_journalnode
-  sudo: yes
+  become: yes
   tasks:
     - name: stop_hadoop-hdfs-journalnode
       service: name=hadoop-hdfs-journalnode state=stopped

--- a/playbooks/stop_mapreduce_historyserver.yml
+++ b/playbooks/stop_mapreduce_historyserver.yml
@@ -1,5 +1,5 @@
 - hosts: hadoop_mapreduce_historyserver
-  sudo: yes
+  become: yes
   tasks:
     - name: stop_mapreduce-historyserver
       service: name=hadoop-mapreduce-historyserver state=stopped

--- a/playbooks/stop_namenode.yml
+++ b/playbooks/stop_namenode.yml
@@ -1,7 +1,7 @@
 ## 前提1: HDFSがsafemodeになっていること
 #- hosts: hadoop_namenode_primary
-#  sudo: yes
-#  sudo_user: hdfs
+#  become: yes
+#  become_user: hdfs
 #  tasks:
 #    - name: enter_safemode
 #      shell: hdfs dfsadmin -safemode enter
@@ -12,7 +12,7 @@
 #      when: enter_safemode.rc != 0
 
 - hosts: hadoop_namenode
-  sudo: yes
+  become: yes
   tasks:
     - name: stop_hadoop-hdfs-zkfc
       service: name=hadoop-hdfs-zkfc state=stopped

--- a/playbooks/stop_nodemanager.yml
+++ b/playbooks/stop_nodemanager.yml
@@ -1,7 +1,7 @@
 ## 前提1: YARN上でアプリケーションが動作していないこと
 
 - hosts: hadoop_slavenode
-  sudo: yes
+  become: yes
   tasks:
     - name: stop_hadoop-yarn-nodemanager
       service: name=hadoop-yarn-nodemanager state=stopped

--- a/playbooks/stop_resourcemanager.yml
+++ b/playbooks/stop_resourcemanager.yml
@@ -1,7 +1,7 @@
 ## 前提1: YARN上でアプリケーションが動作していないこと
 
 - hosts: hadoop_resourcemanager
-  sudo: yes
+  become: yes
   tasks:
     - name: stop_hadoop-yarn-resourcemanager
       service: name=hadoop-yarn-resourcemanager state=stopped

--- a/playbooks/stop_spark_historyserver.yml
+++ b/playbooks/stop_spark_historyserver.yml
@@ -1,6 +1,6 @@
 - hosts: hadoop_spark_history
-  sudo: yes
-  sudo_user: spark
+  become: yes
+  become_user: spark
   tasks:
     - name: check_status_spark_history_server
       shell: '[ -s ${SPARK_PID_DIR}/spark-spark-org.apache.spark.deploy.history.HistoryServer-1.pid ] && [ -x /proc/$(cat ${SPARK_PID_DIR}/spark-spark-org.apache.spark.deploy.history.HistoryServer-1.pid ) ]'

--- a/playbooks/stop_timelineservice.yml
+++ b/playbooks/stop_timelineservice.yml
@@ -1,5 +1,5 @@
 - hosts: hadoop_timelineservice
-  sudo: yes
+  become: yes
   tasks:
     - name: stop_hadoop-yarn-timelineserver
       service: name=hadoop-yarn-timelineserver state=stopped

--- a/playbooks/stop_zookeeper-server.yml
+++ b/playbooks/stop_zookeeper-server.yml
@@ -1,7 +1,7 @@
 ## 前提1: Zookeeperを利用するサービス(HDFS, YARN, HBase)が全て停止していること
 
 - hosts: hadoop_zookeeperserver
-  sudo: yes
+  become: yes
   tasks:
     - name: stop_zookeeper-server
       service: name=zookeeper-server state=stopped

--- a/playbooks/upgrade_namenode.yml
+++ b/playbooks/upgrade_namenode.yml
@@ -1,5 +1,5 @@
 - hosts: hadoop_namenode
-  sudo: yes
+  become: yes
   tasks:
     - name: start_hadoop-hdfs-zkfc
       service: name=hadoop-hdfs-zkfc state=started


### PR DESCRIPTION
To prevent `DEPRECATED WARNING` messages (when you use Ansible >= 2.1), fix some deprecated notations of Ansible.
