### PR TITLE
Fix kerberos tasks

### DIFF
--- a/playbooks/roles/base/handlers/main.yml
+++ b/playbooks/roles/base/handlers/main.yml
@@ -1,13 +1,17 @@
 - name: Modify keytab permissions for hdfs
   file: path=/etc/hadoop/conf/hdfs.keytab owner=hdfs group=hadoop mode=0400
+  become: yes
   notify: Modify http keytab permissions
 
 - name: Modify http keytab permissions
+  become: yes
   file: path=/etc/hadoop/conf/http.keytab owner=hdfs group=hadoop mode=0400
 
 - name: Modify keytab permissions for mapred
+  become: yes
   file: path=/etc/hadoop/conf/mapred.keytab owner=mapred group=hadoop mode=0400
 
 - name: Modify keytab permissions for yarn
+  become: yes
   file: path=/etc/hadoop/conf/yarn.keytab owner=yarn group=hadoop mode=0400
 

--- a/playbooks/roles/base/handlers/main.yml
+++ b/playbooks/roles/base/handlers/main.yml
@@ -1,5 +1,9 @@
 - name: Modify keytab permissions for hdfs
   file: path=/etc/hadoop/conf/hdfs.keytab owner=hdfs group=hadoop mode=0400
+  notify: Modify http keytab permissions
+
+- name: Modify http keytab permissions
+  file: path=/etc/hadoop/conf/http.keytab owner=hdfs group=hadoop mode=0400
 
 - name: Modify keytab permissions for mapred
   file: path=/etc/hadoop/conf/mapred.keytab owner=mapred group=hadoop mode=0400

--- a/playbooks/roles/base/handlers/main.yml
+++ b/playbooks/roles/base/handlers/main.yml
@@ -1,0 +1,9 @@
+- name: Modify keytab permissions for hdfs
+  file: path=/etc/hadoop/conf/hdfs.keytab owner=hdfs group=hadoop mode=0400
+
+- name: Modify keytab permissions for mapred
+  file: path=/etc/hadoop/conf/mapred.keytab owner=mapred group=hadoop mode=0400
+
+- name: Modify keytab permissions for yarn
+  file: path=/etc/hadoop/conf/yarn.keytab owner=yarn group=hadoop mode=0400
+

--- a/playbooks/roles/base/tasks/keytab.yml
+++ b/playbooks/roles/base/tasks/keytab.yml
@@ -9,6 +9,4 @@
 - name: run_script
   shell: ktutil </home/ansible/merge-keytabs.ktutil
   when: kerberos_princ_dest_keytab_stat.stat.exists == False
-
-- name: Modify permissions of keytab
-  file: path={{ kerberos_princ_dest_keytab }} owner={{ kerberos_princ_keytab_owner }} group=hadoop mode=0400
+  notify: "Modify keytab permissions for {{ kerberos_princ_keytab_owner }}"

--- a/playbooks/roles/base/tasks/principal.yml
+++ b/playbooks/roles/base/tasks/principal.yml
@@ -17,5 +17,3 @@
   command: kadmin -q "ktadd -k {{ kerberos_princ_keytab_path }} {{ kerberos_princ_username }}/{{ ansible_fqdn }}" -p {{ kerberos_admin_principal }} -k -t {{ kerberos_admin_keytab }}
   when: target_keytabs is defined and target_keytabs.rc != 0 or target_keytabs.stdout.find(kerberos_princ_username + '/' + ansible_fqdn) == -1
 
-- name: Modify permissions of keytab
-  file: path={{ kerberos_princ_keytab_path }} owner={{ kerberos_princ_keytab_owner }} group=hadoop mode=0400


### PR DESCRIPTION
When a secure hadoop is installed for the first time, some tasks are failed due to some users are missing.

To solve the problem, some tasks are changed to handlers.