### PR TITLE
Update jdk8 to the latest version

### DIFF
--- a/playbooks/group_vars/all/java8
+++ b/playbooks/group_vars/all/java8
@@ -1,4 +1,4 @@
 jdk8_tmppath: '/tmp'
 
 # 依存: jdk8_md5sum
-jdk8_md5sum: 'be6abc353ef797755c1c9260c27422e9'
+jdk8_md5sum: '25b37dc93828cc24e2c246cf6f4a5aac'

--- a/playbooks/group_vars/all/site-defaults
+++ b/playbooks/group_vars/all/site-defaults
@@ -3,7 +3,7 @@
 jdk7_version: '75'
 
 ## 依存: jdk8_md5sum
-jdk8_version: '31'
+jdk8_version: '112'
 
 # HDP
 hdp_version: '2.2.0.0-2041'


### PR DESCRIPTION
Update a version number and hash of default variables for the latest JDK.

You should download `jdk-8u112-linux-x64.rpm` from oracle website, put your server(can be accessed from your cluster) and set `jdk8_downloadurl`.