### PR TITLE
Fix with_items for Ansible 2.2

### DIFF
--- a/playbooks/roles/cgroups/tasks/resource.yml
+++ b/playbooks/roles/cgroups/tasks/resource.yml
@@ -1,10 +1,10 @@
 - name: create_settings_cgroups_group_settings
   become: yes
   template: src=settings.sh.j2 dest={{ cgroups_scripts_dir }}/settings/group/{{ item.group }} owner=root group=root mode=755
-  with_items: cgroups_group_settings
+  with_items: "{{ cgroups_group_settings }}"
 
 - name: create_settings_cgroups_process_settings
   become: yes
   template: src=settings.sh.j2 dest={{ cgroups_scripts_dir }}/settings/process/{{ item.process }} owner=root group=root mode=755
-  with_items: cgroups_process_settings
+  with_items: "{{ cgroups_process_settings }}"
 

--- a/playbooks/roles/datanode_server_deletedata/tasks/delete.yml
+++ b/playbooks/roles/datanode_server_deletedata/tasks/delete.yml
@@ -1,7 +1,7 @@
 - name: check_datanode_data_dirs
   become: yes
   shell: ls {{ item }}/*
-  with_items: dfs_datanode_data_dirs
+  with_items: "{{ dfs_datanode_data_dirs }}"
   register: check_datanode_data_dirs
   changed_when: false
   failed_when: false
@@ -10,11 +10,11 @@
 - name: delete_datanode_data_dirs
   become: yes
   file: path={{ item.item }} state=absent
-  with_items: check_datanode_data_dirs.results
+  with_items: "{{ check_datanode_data_dirs.results }}"
   when: item.rc == 0
   
 - name: recreate_datanode_data_dirs
   become: yes
   file: path={{ item.item }} state=directory mode=755 owner=hdfs group=hadoop
-  with_items: check_datanode_data_dirs.results
+  with_items: "{{ check_datanode_data_dirs.results }}"
   when: item.rc == 0

--- a/playbooks/roles/hdfs_base/tasks/config.yml
+++ b/playbooks/roles/hdfs_base/tasks/config.yml
@@ -30,19 +30,19 @@
   become_user: hdfs
   shell: hdfs dfs -mkdir -p {{ item.item.path }}
   when: item.rc != 0
-  with_items: check_exists_hdfs_dir.results
+  with_items: "{{ check_exists_hdfs_dir.results }}"
   
 - name: change_owner_and_group_of_hdfs_dir
   become: yes
   become_user: hdfs
   shell: hdfs dfs -chown -R {{ item.item.owner }}:{{ item.item.group }} {{ item.item.path }}
   when: item.rc != 0
-  with_items: check_exists_hdfs_dir.results
+  with_items: "{{ check_exists_hdfs_dir.results }}"
 
 - name: change_mode_of_hdfs_dir
   become: yes
   become_user: hdfs
   shell: hdfs dfs -chmod -R {{ item.item.mode }} {{ item.item.path }}
   when: item.rc != 0
-  with_items: check_exists_hdfs_dir.results
+  with_items: "{{ check_exists_hdfs_dir.results }}"
 

--- a/playbooks/roles/hdfs_yarn/tasks/config.yml
+++ b/playbooks/roles/hdfs_yarn/tasks/config.yml
@@ -20,19 +20,19 @@
   become_user: hdfs
   shell: hdfs dfs -mkdir -p {{ item.item.path }}
   when: item.rc != 0
-  with_items: check_exists_hdfs_dir.results
+  with_items: "{{ check_exists_hdfs_dir.results }}"
   
 - name: change_owner_and_group_of_hdfs_dir
   become: yes
   become_user: hdfs
   shell: hdfs dfs -chown -R {{ item.item.owner }}:{{ item.item.group }} {{ item.item.path }}
   when: item.rc != 0
-  with_items: check_exists_hdfs_dir.results
+  with_items: "{{ check_exists_hdfs_dir.results }}"
 
 - name: change_mode_of_hdfs_dir
   become: yes
   become_user: hdfs
   shell: hdfs dfs -chmod -R {{ item.item.mode }} {{ item.item.path }}
   when: item.rc != 0
-  with_items: check_exists_hdfs_dir.results
+  with_items: "{{ check_exists_hdfs_dir.results }}"
 

--- a/playbooks/roles/namenode/tasks/config.yml
+++ b/playbooks/roles/namenode/tasks/config.yml
@@ -1,7 +1,7 @@
 - name: create_namenode_data_dir
   become: yes
   file: path={{ item }} state=directory owner=hdfs group=hadoop mode=700
-  with_items: dfs_namenode_name_dirs
+  with_items: "{{ dfs_namenode_name_dirs }}"
 
 - name: fix_init_scripts
   become: yes

--- a/playbooks/roles/namenode_format/tasks/config.yml
+++ b/playbooks/roles/namenode_format/tasks/config.yml
@@ -1,7 +1,7 @@
 - name: check_format_state
   become: yes
   stat: path={{ item }}/current
-  with_items: dfs_namenode_name_dirs
+  with_items: "{{ dfs_namenode_name_dirs }}"
 
 - name: FORMAT_namenode
   become: yes

--- a/playbooks/roles/slavenode/tasks/config.yml
+++ b/playbooks/roles/slavenode/tasks/config.yml
@@ -1,7 +1,7 @@
 - name: create_datanode_data_dir
   become: yes
   file: path={{ item }} state=directory owner=hdfs group=hadoop mode=700
-  with_items: dfs_datanode_data_dirs
+  with_items: "{{ dfs_datanode_data_dirs }}"
 
 - name: fix_init_scripts
   become: yes


### PR DESCRIPTION
There are some with_items statements, which rely on old Ansible syntax, and they do not work expectedly on Ansible 2.2.

Fix them to work on Ansible 2.2.