### PR TITLE
Add hive user to proxyuser

### DIFF
--- a/playbooks/roles/base/templates/core-site.xml.j2
+++ b/playbooks/roles/base/templates/core-site.xml.j2
@@ -105,4 +105,14 @@
   <value>*</value>
 </property>
 
+<property>
+  <name>hadoop.proxyuser.hive.hosts</name>
+  <value>*</value>
+</property>
+
+<property>
+  <name>hadoop.proxyuser.hive.groups</name>
+  <value>*</value>
+</property>
+
 </configuration>


### PR DESCRIPTION
To run HiveServer2, added hive user to `proxyuser`.

As a result of this PR, All users can access Hadoop resources through HiveServer2 in Kerberized cluster.