### PR TITLE
Add *_http_policy configurations

### DIFF
--- a/playbooks/group_vars/all/base
+++ b/playbooks/group_vars/all/base
@@ -30,6 +30,7 @@ namenode_http_port: '50070'
 
 namenode_https_port: '50470'
 
+datanode_http_policy: 'HTTPS_ONLY'
 datanode_https_port: '50470'
 
 # https://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.6.5/bk_command-line-installation/content/configuring-namenode-heap-size.html
@@ -87,6 +88,10 @@ mapreduce_reduce_memory_mb: '1024'
 
 ## 依存: mapreduce_reduce_memory_mb
 mapreduce_reduce_java_opts: '-Xmx768m'
+
+mapreduce_http_policy: 'HTTPS_ONLY'
+
+yarn_http_policy: 'HTTPS_ONLY'
 
 # hadoop-env
 hdfs_ident_string: 'hdfs'

--- a/playbooks/roles/base/templates/hdfs-site.xml.j2
+++ b/playbooks/roles/base/templates/hdfs-site.xml.j2
@@ -39,7 +39,7 @@
 
 <property>
   <name>dfs.http.policy</name>
-  <value>HTTPS_ONLY</value>
+  <value>{{ datanode_http_policy }}</value>
 </property>
 
 <property>

--- a/playbooks/roles/base/templates/mapred-site.xml.j2
+++ b/playbooks/roles/base/templates/mapred-site.xml.j2
@@ -31,7 +31,7 @@
 
   <property>
     <name>mapreduce.jobhistory.http.policy</name>
-    <value>HTTPS_ONLY</value>
+    <value>{{ mapreduce_http_policy }}</value>
   </property>
 {% endif %}
 

--- a/playbooks/roles/base/templates/yarn-site.xml.j2
+++ b/playbooks/roles/base/templates/yarn-site.xml.j2
@@ -47,7 +47,7 @@
 
 <property>
   <name>yarn.http.policy</name>
-  <value>HTTPS_ONLY</value>
+  <value>{{ yarn_http_policy }}</value>
 </property>
 
 {% for host in hadoop_resourcemanager_servers %}


### PR DESCRIPTION
This pull request introduces changes to improve the configurability of HTTP policies for Hadoop components by replacing hardcoded values with variables. These changes allow for greater flexibility in managing HTTP and HTTPS settings across different environments.

Added new variables `datanode_http_policy`, `mapreduce_http_policy`, and `yarn_http_policy`, all set to `'HTTPS_ONLY'` by default. These variables will control the HTTP policies for DataNode, MapReduce, and YARN, respectively. 