### PR TITLE
Fix kerberos-client sshd handler for Ubuntu 24.04

### DIFF
--- a/playbooks/roles/kerberos-client/handlers/main.yml
+++ b/playbooks/roles/kerberos-client/handlers/main.yml
@@ -1,3 +1,4 @@
 - name: Reload sshd
   become: yes
   service: name=sshd state=reloaded
+  when: not (ansible_distribution == "Ubuntu" and ansible_distribution_version is version("24.04", ">="))


### PR DESCRIPTION
Skip Reload sshd handler on Ubuntu 24.04+ where sshd service management has changed, preventing the handler execution error below:

```
RUNNING HANDLER [kerberos-client : Reload sshd] ********************************
fatal: [xxx.xxx.xxx.xxx]: FAILED! => {"changed": false, "msg": "Could not find the requested service sshd: host"}
```

Related to: https://discourse.ubuntu.com/t/sshd-now-uses-socket-based-activation-ubuntu-22-10-and-later/30189
